### PR TITLE
make worker_liveness_sec an option for more customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ OPTIONS:
         --report-timeout N           Fail if build is not finished after N seconds. Only applicable if --report is enabled (default: 3600).
         --max-requeues N             Retry failed examples up to N times before considering them legit failures (default: 3).
         --queue-wait-timeout N       Time to wait for a queue to be ready before considering it failed (default: 30).
+        --worker_liveness_sec N      Worker liveness timeout in seconds, node will be considered dead if it hasn't emitted a heartbeat for N seconds (default: 60).
         --fail-fast N                Abort build with a non-zero status code after N failed examples.
         --reproduction               Enable reproduction mode: Publish files and examples in the exact order given in the command. Incompatible with --timings.
     -h, --help                       Show this message.
@@ -102,6 +103,7 @@ $ RSPECQ_BUILD=123 RSPECQ_WORKDER=foo1 rspecq spec/
 | `RSPECQ_MAX_REQUEUES` | Max requests |
 | `RSPECQ_QUEUE_WAIT_TIMEOUT` | Queue wait timeout |
 | `RSPECQ_REDIS_URL` | Redis URL |
+| `RSPECQ_WORKER_LIVENESS_SEC` | Worker liveness timeout in seconds |
 | `RSPECQ_FAIL_FAST` | Fail fast |
 | `RSPECQ_REPORTER_RERUN_COMMAND_SKIP` | Do not report flaky test's rerun command |
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ MRI etc.
 For resiliency against such issues, workers emit a heartbeat after each
 example they execute, to signal
 that they're healthy and performing jobs as expected. If a worker hasn't
-emitted a heartbeat for a given amount of time (set by `WORKER_LIVENESS_SEC`)
+emitted a heartbeat for a given amount of time (set by the `worker_liveness_sec` option)
 it is considered dead and its reserved job will be put back to the queue, to
 be picked up by another healthy worker.
 

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -10,7 +10,8 @@ if config.report?
     build_id: config.build,
     timeout: config.report_timeout,
     redis_opts: config.redis_opts,
-    queue_wait_timeout: config.queue_wait_timeout
+    queue_wait_timeout: config.queue_wait_timeout,
+    worker_liveness_sec: config.worker_liveness_sec
   )
 
   reporter.report
@@ -18,7 +19,8 @@ else
   worker = RSpecQ::Worker.new(
     build_id: config.build,
     worker_id: config.worker,
-    redis_opts: config.redis_opts
+    redis_opts: config.redis_opts,
+    worker_liveness_sec: config.worker_liveness_sec
   )
 
   worker.files_or_dirs_to_run = config.files_or_dirs_to_run if config.files_or_dirs_to_run

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -1,10 +1,6 @@
 require "rspec/core"
 require "sentry-ruby"
 
-module RSpecQ
-  # See configuration and parser for the worker_liveness_sec option.
-end
-
 require_relative "rspecq/formatters/example_count_recorder"
 require_relative "rspecq/formatters/failure_recorder"
 require_relative "rspecq/formatters/job_timing_recorder"

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -2,10 +2,7 @@ require "rspec/core"
 require "sentry-ruby"
 
 module RSpecQ
-  # If a worker haven't executed an example for more than WORKER_LIVENESS_SEC
-  # seconds, it is considered dead and its reserved work will be put back
-  # to the queue to be picked up by another worker.
-  WORKER_LIVENESS_SEC = 60.0
+  # See configuration and parser for the worker_liveness_sec option.
 end
 
 require_relative "rspecq/formatters/example_count_recorder"

--- a/lib/rspecq/configuration.rb
+++ b/lib/rspecq/configuration.rb
@@ -32,9 +32,6 @@ module RSpecQ
     def initialize(args)
       super(**RSpecQ::Parser.parse!(args))
 
-      # Set constant RspecQ WORKER_LIVENESS_SEC after parsing options
-      ::RSpecQ.const_set(:WORKER_LIVENESS_SEC, self.worker_liveness_sec)
-
       self.files_or_dirs_to_run = RSpec::Core::Parser.new(args).parse[:files_or_directories_to_run]
       l = files_or_dirs_to_run.length
       if l.zero?

--- a/lib/rspecq/formatters/worker_heartbeat_recorder.rb
+++ b/lib/rspecq/formatters/worker_heartbeat_recorder.rb
@@ -2,7 +2,7 @@ module RSpecQ
   module Formatters
     # Updates the respective heartbeat key of the worker after each example.
     #
-    # Refer to the documentation of WORKER_LIVENESS_SEC for more info.
+    # Refer to the documentation of the worker_liveness_sec configuration option for more info.
     class WorkerHeartbeatRecorder
       def initialize(worker)
         @worker = worker

--- a/lib/rspecq/parser.rb
+++ b/lib/rspecq/parser.rb
@@ -7,6 +7,7 @@ module RSpecQ
     DEFAULT_MAX_REQUEUES = 3
     DEFAULT_QUEUE_WAIT_TIMEOUT = 30
     DEFAULT_FAIL_FAST = 0
+    DEFAULT_WORKER_LIVENESS_SEC = 60
 
     def self.parse!(args)
       new(args).parse!
@@ -53,88 +54,88 @@ module RSpecQ
         o.separator "OPTIONS:"
 
         o.on("-b", "--build ID", "A unique identifier for the build. Should be " \
-            "common among workers participating in the same build.") do |v|
+                                 "common among workers participating in the same build.") do |v|
           opts[:build] = v
         end
 
         o.on("-w", "--worker ID", "An identifier for the worker. Workers " \
-            "participating in the same build should have distinct IDs.") do |v|
+                                  "participating in the same build should have distinct IDs.") do |v|
           opts[:worker] = v
         end
 
         o.on("--seed SEED", "The RSpec seed. Passing the seed can be helpful in " \
-          "many ways i.e reproduction and testing.") do |v|
+                            "many ways i.e reproduction and testing.") do |v|
           opts[:seed] = v
         end
 
         o.on("-r", "--redis HOST", "Redis host to connect to " \
-            "(default: #{DEFAULT_REDIS_HOST}).") do |v|
+                                   "(default: #{DEFAULT_REDIS_HOST}).") do |v|
           puts "--redis is deprecated. Use --redis-host or --redis-url instead"
           opts[:redis_host] = v
         end
 
         o.on("--redis-host HOST", "Redis host to connect to " \
-            "(default: #{DEFAULT_REDIS_HOST}).") do |v|
+                                  "(default: #{DEFAULT_REDIS_HOST}).") do |v|
           opts[:redis_host] = v
         end
 
         o.on("--redis-url URL", "The URL of the Redis host to connect to " \
-            "(e.g.: redis://127.0.0.1:6379/0).") do |v|
+                                "(e.g.: redis://127.0.0.1:6379/0).") do |v|
           opts[:redis_url] = v
         end
 
-        o.on("--update-timings", "Update the global job timings key with the "     \
-            "timings of this build. Note: This key is used as the basis for job " \
-            "scheduling.") do |v|
+        o.on("--update-timings", "Update the global job timings key with the " \
+                                 "timings of this build. Note: This key is used as the basis for job " \
+                                 "scheduling.") do |v|
           opts[:timings] = v
         end
 
         o.on("--file-split-threshold N", Integer, "Split spec files slower than N " \
-            "seconds and schedule them as individual examples.") do |v|
+                                                  "seconds and schedule them as individual examples.") do |v|
           opts[:file_split_threshold] = v
         end
 
         o.on("--report", "Enable reporter mode: do not pull tests off the queue; " \
-                        "instead print build progress and exit when it's "        \
-                        "finished.\n#{o.summary_indent * 9} "                       \
-                        "Exits with a non-zero status code if there were any "    \
-                        "failures.") do |v|
+                         "instead print build progress and exit when it's " \
+                         "finished.\n#{o.summary_indent * 9} " \
+                         "Exits with a non-zero status code if there were any " \
+                         "failures.") do |v|
           opts[:report] = v
         end
 
         o.on("--report-timeout N", Integer, "Fail if build is not finished after " \
-            "N seconds. Only applicable if --report is enabled "                  \
-            "(default: #{DEFAULT_REPORT_TIMEOUT}).") do |v|
+                                            "N seconds. Only applicable if --report is enabled " \
+                                            "(default: #{DEFAULT_REPORT_TIMEOUT}).") do |v|
           opts[:report_timeout] = v
         end
 
-        o.on("--max-requeues N", Integer, "Retry failed examples up to N times "   \
-            "before considering them legit failures "                             \
-            "(default: #{DEFAULT_MAX_REQUEUES}).") do |v|
+        o.on("--max-requeues N", Integer, "Retry failed examples up to N times " \
+                                          "before considering them legit failures " \
+                                          "(default: #{DEFAULT_MAX_REQUEUES}).") do |v|
           opts[:max_requeues] = v
         end
 
-        o.on("--queue-wait-timeout N", Integer, "Time to wait for a queue to be "   \
-            "ready before considering it failed "                                  \
-            "(default: #{DEFAULT_QUEUE_WAIT_TIMEOUT}).") do |v|
+        o.on("--queue-wait-timeout N", Integer, "Time to wait for a queue to be " \
+                                                "ready before considering it failed " \
+                                                "(default: #{DEFAULT_QUEUE_WAIT_TIMEOUT}).") do |v|
           opts[:queue_wait_timeout] = v
         end
 
         o.on("--fail-fast N", Integer, "Abort build with a non-zero status code " \
-            "after N failed examples.") do |v|
+                                       "after N failed examples.") do |v|
           opts[:fail_fast] = v
         end
 
         o.on("--reproduction", "Enable reproduction mode: run rspec on the given files " \
-            "and examples in the exact order they are given. Incompatible with " \
-            "--timings.") do |v|
+                               "and examples in the exact order they are given. Incompatible with " \
+                               "--timings.") do |v|
           opts[:reproduction] = v
         end
 
-        o.on("--junit-output filepath", String, "Output junit formatted xml "    \
-            "for CI suites to the defined file path. Substitution parameters "  \
-            "{{TEST_ENV_NUMBER}} - parallel gem proc number. "                  \
-            "{{JOB_INDEX}} - increments with each suite that is run.") do |v|
+        o.on("--junit-output filepath", String, "Output junit formatted xml " \
+                                                "for CI suites to the defined file path. Substitution parameters " \
+                                                "{{TEST_ENV_NUMBER}} - parallel gem proc number. " \
+                                                "{{JOB_INDEX}} - increments with each suite that is run.") do |v|
           opts[:junit_output] = v
         end
 
@@ -144,6 +145,11 @@ module RSpecQ
 
         o.on("--exclude-pattern PATTERN", "Regex of tests to exclude from run.") do |v|
           opts[:exclude_pattern] = /#{v}/
+        end
+
+        o.on("--worker-liveness-sec N", Integer, "Seconds before a worker is considered dead " \
+                                                 "(default: #{DEFAULT_WORKER_LIVENESS_SEC})") do |v|
+          opts[:worker_liveness_sec] = v
         end
 
         o.on_tail("-h", "--help", "Show this message.") do
@@ -175,6 +181,7 @@ module RSpecQ
       opts[:junit_output] ||= ENV["RSPECQ_JUNIT_OUTPUT"]
       opts[:include_pattern] ||= ENV["INCLUDE_PATTERN"]
       opts[:exclude_pattern] ||= ENV["EXCLUDE_PATTERN"]
+      opts[:worker_liveness_sec] ||= Integer(ENV["RSPECQ_WORKER_LIVENESS_SEC"] || DEFAULT_WORKER_LIVENESS_SEC)
     end
 
     def env_set?(var)

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -89,10 +89,11 @@ module RSpecQ
 
     attr_reader :redis
 
-    def initialize(build_id, worker_id, redis_opts)
+    def initialize(build_id, worker_id, redis_opts, worker_liveness_sec)
       @build_id = build_id
       @worker_id = worker_id
       @redis = Redis.new(redis_opts.merge(id: worker_id))
+      @worker_liveness_sec = worker_liveness_sec
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)
@@ -125,7 +126,7 @@ module RSpecQ
         ],
         argv: [
           current_time,
-          WORKER_LIVENESS_SEC
+          @worker_liveness_sec
         ]
       )
     end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -9,10 +9,10 @@ module RSpecQ
   #
   # Reporters are readers of the queue.
   class Reporter
-    def initialize(build_id:, timeout:, redis_opts:, queue_wait_timeout: 30)
+    def initialize(build_id:, timeout:, redis_opts:, worker_liveness_sec:, queue_wait_timeout: 30)
       @build_id = build_id
       @timeout = timeout
-      @queue = Queue.new(build_id, "reporter", redis_opts)
+      @queue = Queue.new(build_id, "reporter", redis_opts, worker_liveness_sec)
       @queue_wait_timeout = queue_wait_timeout
 
       # We want feedback to be immediately printed to CI users, so

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -16,10 +16,6 @@ module RSpecQ
   #
   # Workers are readers+writers of the queue.
   class Worker
-    def heartbeat_frequency
-      WORKER_LIVENESS_SEC / 6
-    end
-
     # The root path or individual spec files to execute.
     #
     # Defaults to "spec" (similar to RSpec)
@@ -77,10 +73,12 @@ module RSpecQ
 
     attr_reader :queue
 
-    def initialize(build_id:, worker_id:, redis_opts:)
+    def initialize(build_id:, worker_id:, redis_opts:, worker_liveness_sec:)
       @build_id = build_id
       @worker_id = worker_id
-      @queue = Queue.new(build_id, worker_id, redis_opts)
+      @worker_liveness_sec = worker_liveness_sec
+      @heartbeat_frequency = worker_liveness_sec / 6
+      @queue = Queue.new(build_id, worker_id, redis_opts, worker_liveness_sec)
       @fail_fast = 0
       @files_or_dirs_to_run = ["spec"]
       @populate_timings = false
@@ -165,7 +163,7 @@ module RSpecQ
 
     # Update the worker heartbeat if necessary
     def update_heartbeat
-      if @heartbeat_updated_at.nil? || elapsed(@heartbeat_updated_at) >= heartbeat_frequency
+      if @heartbeat_updated_at.nil? || elapsed(@heartbeat_updated_at) >= @heartbeat_frequency
         queue.record_worker_heartbeat
         @heartbeat_updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -16,7 +16,9 @@ module RSpecQ
   #
   # Workers are readers+writers of the queue.
   class Worker
-    HEARTBEAT_FREQUENCY = WORKER_LIVENESS_SEC / 6
+    def heartbeat_frequency
+      WORKER_LIVENESS_SEC / 6
+    end
 
     # The root path or individual spec files to execute.
     #
@@ -86,7 +88,7 @@ module RSpecQ
       @heartbeat_updated_at = nil
       @max_requeues = 3
       @queue_wait_timeout = 30
-      @seed = srand && srand % 0xFFFF
+      @seed = srand && (srand % 0xFFFF)
       @reproduction = false
       @junit_output = nil
 
@@ -163,7 +165,7 @@ module RSpecQ
 
     # Update the worker heartbeat if necessary
     def update_heartbeat
-      if @heartbeat_updated_at.nil? || elapsed(@heartbeat_updated_at) >= HEARTBEAT_FREQUENCY
+      if @heartbeat_updated_at.nil? || elapsed(@heartbeat_updated_at) >= heartbeat_frequency
         queue.record_worker_heartbeat
         @heartbeat_updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end

--- a/test/test_concurrent_workers.rb
+++ b/test/test_concurrent_workers.rb
@@ -22,7 +22,7 @@ class TestConcurrentWorkers < RSpecQTest
 
     assert_operator elapsed, :<, 5
 
-    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS)
+    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS, 60)
 
     assert_queue_well_formed(queue)
     assert queue.build_successful?

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -135,8 +135,6 @@ class TestEndToEnd < RSpecQTest
 
     assert_includes [2, 3], queue.processed_jobs.length
   end
-<<<<<<< HEAD
-=======
 
   def test_suite_with_rspec_arguments
     queue = exec_build("tagged_suite", "-- --tag foo")
@@ -159,5 +157,4 @@ class TestEndToEnd < RSpecQTest
     assert File.exist?("test/sample_suites/flakey_suite/test/test_results/test.1.xml")
     assert File.exist?("test/sample_suites/flakey_suite/test/test_results/test.2.xml")
   end
->>>>>>> 74202f3... Add ability to define formatter file name and path.
 end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -136,12 +136,6 @@ class TestEndToEnd < RSpecQTest
     assert_includes [2, 3], queue.processed_jobs.length
   end
 
-  def test_suite_with_rspec_arguments
-    queue = exec_build("tagged_suite", "-- --tag foo")
-
-    assert_equal 1, queue.example_count
-  end
-
   def test_suite_with_junit_output
     queue = exec_build("flakey_suite",
                        "--junit-output test/test_results/test.{{JOB_INDEX}}.xml")

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -14,7 +14,8 @@ module TestHelpers
     w = RSpecQ::Worker.new(
       build_id: rand_id,
       worker_id: rand_id,
-      redis_opts: REDIS_OPTS
+      redis_opts: REDIS_OPTS,
+      worker_liveness_sec: 60
     )
     w.files_or_dirs_to_run = suite_path(path)
     w
@@ -38,7 +39,7 @@ module TestHelpers
 
     assert_equal 0, $?.exitstatus
 
-    queue = RSpecQ::Queue.new(build_id, worker_id, REDIS_OPTS)
+    queue = RSpecQ::Queue.new(build_id, worker_id, REDIS_OPTS, 60)
     assert_queue_well_formed(queue)
 
     queue

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -6,7 +6,7 @@ class TestQueue < RSpecQTest
 
     Process.wait(start_worker(build_id: build_id, suite: "flaky_job_detection"))
 
-    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS)
+    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS, 60)
 
     assert_queue_well_formed(queue)
     refute queue.build_successful?


### PR DESCRIPTION
worker_liveness_sec is currently a constant set at 60 seconds. If you have any long running rspec tests this will trigger the requeue_lost_job even though the worker is still active and running. Having worker_liveness_sec as an option allows for customization of long running tests that run longer than 60 seconds.